### PR TITLE
1second delay when reset is received to allow response

### DIFF
--- a/src/chargepoint/ocpp/ChargePointEventsHandler.cpp
+++ b/src/chargepoint/ocpp/ChargePointEventsHandler.cpp
@@ -412,7 +412,13 @@ bool ChargePointEventsHandler::getLocalLimitationsSchedule(unsigned int         
 bool ChargePointEventsHandler::resetRequested(ocpp::types::ResetType reset_type)
 {
     cout << "Reset requested : " << ResetTypeHelper.toString(reset_type) << endl;
-    m_reset_pending = true;
+    std::thread executor = std::thread(
+        [&]
+        {
+            std::this_thread::sleep_for(1s);
+            m_reset_pending = true;
+        });
+    executor.detach();
     return true;
 }
 


### PR DESCRIPTION
When simu recevied reset ocpp message, stack doesn't have the time to response "accepted". The connection is closed too quick